### PR TITLE
업적 달성 메서드(clearAchieve) 오류 해결

### DIFF
--- a/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/achieve/AchieveActivity.kt
+++ b/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/achieve/AchieveActivity.kt
@@ -1,5 +1,6 @@
 package com.example.shape_up_2022.achieve
 
+import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import com.example.shape_up_2022.adapter.AchieveAdapter
@@ -183,15 +184,15 @@ class AchieveActivity : AppCompatActivity() {
             }
         }
 
-        fun clearAchieve(position: Int){
+        fun clearAchieve(context: Context, position: Int){
             // 프리퍼런스 값 바꾸기
-            val temp = SaveSharedPreference.getAchieve(this)!!
+            val temp = SaveSharedPreference.getAchieve(context)!!
             temp[position] = true
-            SaveSharedPreference.setAchieve(this, temp)
+            SaveSharedPreference.setAchieve(context, temp)
 
             // 라우터 연결, 업데이트
             val call: Call<CompleteAchieveRes> = MyApplication.networkServiceUsers.setCheckedTrue(
-                userID = SaveSharedPreference.getUserID(this)!!, position = position
+                userID = SaveSharedPreference.getUserID(context)!!, position = position
              )
 
             call?.enqueue(object : Callback<CompleteAchieveRes> {

--- a/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/auth/LoginActivity.kt
+++ b/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/auth/LoginActivity.kt
@@ -55,10 +55,11 @@ class LoginActivity : AppCompatActivity() {
                             SaveSharedPreference.setFamliyID(baseContext, response.body()!!.user.familyID?:null) // familyID
                             SaveSharedPreference.setUserTested(baseContext, response.body()!!.user.tested) // 성향점검 여부
                             SaveSharedPreference.setAchieve(baseContext, response.body()!!.user.achieve) // 업적 달성 여부
+                            Log.d("mobileApp", "${response.body()!!.user.achieve}")
 
                             // petID 프리퍼런스에 저장
                             if(response.body()!!.user.familyID != null){
-                                //Log.d("")
+                                Log.d("mobileApp", " familyID: ${response.body()!!.user.familyID!!}")
                                 callGetPetID(response.body()!!.user.familyID!!)
                             } else{
                                 // 메인 페이지로 이동

--- a/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/common/MainActivity.kt
+++ b/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/common/MainActivity.kt
@@ -155,7 +155,11 @@ class MainActivity : AppCompatActivity() {
                     Log.d("mobileApp", "$response ${response.body()}")
                     if(response.body()!!.success){
                         // 강아지 이름 업데이트
+                        binding.homeInfoDog.visibility = View.VISIBLE
                         binding.puppyProfileName.text = response.body()?.petInfo?.name
+                    } else{
+                        binding.homeInfoDog.visibility = View.GONE
+                        binding.noFamHomeInfoDog.visibility = View.VISIBLE
                     }
                 }
             }

--- a/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/simulation/SimStartNamingActivity.kt
+++ b/SHAPEUP2022/app/src/main/java/com/example/shape_up_2022/simulation/SimStartNamingActivity.kt
@@ -68,10 +68,18 @@ class SimStartNamingActivity : AppCompatActivity() {
                     // 강아지 입양 및 이름 등록
                     postRegisterPet(petName)
 
+                    // 강아지 업적 달성 position: 0
+                    val check = SaveSharedPreference.getAchieve(baseContext)!![0] // 업적 달성 여부 확인
+
+                    if(!check){ // 업적을 1번도 달성하지 않았었다면
+                        AchieveActivity().clearAchieve(this@SimStartNamingActivity, 0) // 업적 달성 업데이트 실행
+                    }
+
                     binding.nameStep1.visibility = View.GONE
                     binding.nameStep2.visibility = View.GONE
                     binding.nameStep3.visibility = View.GONE
                     binding.nameStep4.visibility = View.VISIBLE
+
                 }
             }
         }
@@ -89,13 +97,6 @@ class SimStartNamingActivity : AppCompatActivity() {
                 .setCancelable(false)
 
             builder.show()
-
-            // 강아지 업적 달성 position: 0
-            val check = SaveSharedPreference.getAchieve(this)!![0] // 업적 달성 여부 확인
-            if(!check){ // 업적을 1번도 달성하지 않았었다면
-                AchieveActivity().clearAchieve(0) // 업적 달성 업데이트 실행
-            }
-            
         }
     }
 

--- a/SHAPEUP2022/app/src/main/res/layout/main_page.xml
+++ b/SHAPEUP2022/app/src/main/res/layout/main_page.xml
@@ -76,7 +76,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textSize="15dp"
-                    android:text="가족 그룹에 가입하면 반려견을 입양할 수 있어요!"
+                    android:text="아직 강아지를 입양하지 않았어요!"
                     android:textAlignment="center"/>
             </LinearLayout>
 


### PR DESCRIPTION
### 업적 목록 중 하나를 달성했을 때
함수가 실행되는 액티비티의 context와 position(업적 아이템 순서)를 보내줌
업적 순서의 경우 array.xml을 참고 

```kotlin
        /* 준비도: progressBar */
        private fun DisplayProgress(){
            var clearCount = 0
            if(SaveSharedPreference.getAchieve(this)!! == null){
                binding.pbAchieveTodo.progress = 0
            } else{
                val checkedArray = SaveSharedPreference.getAchieve(this)!!
                for(i in 0 until checkedArray.size){
                    if(checkedArray[i]) clearCount++
                    if(i == checkedArray.size - 1){ // 마지막 인덱스일 때
                        // 준비도 반영하기
                        val ratio = (clearCount.toFloat() / 14)
                        Log.d("mobileApp", "$ratio")
                        binding.pbAchieveTodo.progress = (ratio * 100).toInt()
                    }
                }
            }
        }
```